### PR TITLE
Fix/itch download downgrade connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ The step configuration looks like this:
     action: "push"
     # Where Butler should be installed.
     install_dir: ~/.butler
+    # Where Butler should be downloaded from.
+    butler_source: "https://broth.itch.ovh/butler"
 
     ###### Push options ######
     # Your butler key (see https://itch.io/user/settings/api-keys)

--- a/__tests__/executor.test.ts
+++ b/__tests__/executor.test.ts
@@ -30,7 +30,10 @@ beforeEach(async () => {
 
   const spyTcDownloadTool = jest.spyOn(tc, 'downloadTool');
   spyTcDownloadTool.mockImplementation(async (url, dest) => {
-    const filename = url.split('/').pop() as string;
+    const filename = `${url.split('/').pop()}-${url
+      .split('')
+      .map(c => c.charCodeAt(0))
+      .reduce((p, v) => p + v, 0)}`;
     const cache_path = path.join(cache_dir, filename);
     if (fs.existsSync(cache_path)) {
       if (dest) {
@@ -41,7 +44,7 @@ beforeEach(async () => {
       return fs.realpathSync(dest);
     }
     return new Promise((resolve, reject) => {
-      const req = https.get(url, res => {
+      https.get(url, res => {
         if (res.statusCode && res.statusCode >= 400) {
           reject('Received error code');
         }

--- a/__tests__/executor.test.ts
+++ b/__tests__/executor.test.ts
@@ -21,6 +21,7 @@ beforeEach(async () => {
     action: 'push',
     install_dir: tmpdir,
     install_opt: {
+      butler_source: 'https://broth.itch.zone/butler',
       butler_version: 'latest',
       check_signature: false,
       update_path: false

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
 
   check_signature:
     description: "Should the signature of the downloaded Butler executable be verified"
-    default: "true"
+    default: "false"
   update_path:
     description: "Whether to update the PATH"
     default: "false"

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   install_dir:
     description: "Where the SDK should be installed"
     required: false
+  butler_source:
+    description: "Where Butler should be downloaded from"
+    default: "https://broth.itch.zone/butler"
 
   check_signature:
     description: "Should the signature of the downloaded Butler executable be verified"

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -29189,7 +29189,7 @@ class ButlerExecutor {
     install(opts) {
         return __awaiter(this, void 0, void 0, function* () {
             core.startGroup('Install Butler');
-            const download_url = this.getInstallUrl(opts.butler_version);
+            const download_url = this.getInstallUrl(opts.butler_source, opts.butler_version);
             core.info(`Downloading Butler from ${download_url}`);
             const downloaded_path = yield tc.downloadTool(download_url);
             fs.mkdirSync(this.install_dir, { recursive: true });
@@ -29322,11 +29322,11 @@ class ButlerExecutor {
         }
         return res.join('-');
     }
-    getInstallUrl(version) {
-        return util.format('https://broth.itch.ovh/butler/%s/%s/archive/default', (0, utils_1.getButlerOsPath)(), version.toUpperCase());
+    getInstallUrl(source, version) {
+        return `${source}/${(0, utils_1.getButlerOsPath)()}/${version.toUpperCase()}/archive/default`;
     }
-    getSignatureUrl(version) {
-        return util.format('https://broth.itch.ovh/butler/%s/%s/signature/default', (0, utils_1.getButlerOsPath)(), version.toUpperCase());
+    getSignatureUrl(source, version) {
+        return `${source}/${(0, utils_1.getButlerOsPath)()}/${version.toUpperCase()}/signature/default`;
     }
     getExecutablePath() {
         let executable_name = 'butler';
@@ -29386,7 +29386,8 @@ function parseInputs() {
         action,
         install_dir,
         install_opt: {
-            check_signature: (0, utils_1.stringToBool)(core.getInput('check_signature'), true),
+            butler_source: core.getInput('butler_source') || 'https://broth.itch.zone/butler',
+            check_signature: (0, utils_1.stringToBool)(core.getInput('check_signature'), false),
             update_path: (0, utils_1.stringToBool)(core.getInput('update_path'), false),
             butler_version: core.getInput('butler_version') || 'latest'
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "butler-to-itch",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "description": "Setup renpy action",
   "author": "Ayowel",

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -20,7 +20,7 @@ export class ButlerExecutor {
 
   public async install(opts: CommandInstallOptions) {
     core.startGroup('Install Butler');
-    const download_url = this.getInstallUrl(opts.butler_version);
+    const download_url = this.getInstallUrl(opts.butler_source, opts.butler_version);
     core.info(`Downloading Butler from ${download_url}`);
     const downloaded_path = await tc.downloadTool(download_url);
     fs.mkdirSync(this.install_dir, { recursive: true });
@@ -180,20 +180,12 @@ export class ButlerExecutor {
     return res.join('-');
   }
 
-  protected getInstallUrl(version: string): string {
-    return util.format(
-      'https://broth.itch.ovh/butler/%s/%s/archive/default',
-      getButlerOsPath(),
-      version.toUpperCase()
-    );
+  protected getInstallUrl(source: string, version: string): string {
+    return `${source}/${getButlerOsPath()}/${version.toUpperCase()}/archive/default`;
   }
 
-  protected getSignatureUrl(version: string): string {
-    return util.format(
-      'https://broth.itch.ovh/butler/%s/%s/signature/default',
-      getButlerOsPath(),
-      version.toUpperCase()
-    );
+  protected getSignatureUrl(source: string, version: string): string {
+    return `${source}/${getButlerOsPath()}/${version.toUpperCase()}/signature/default`;
   }
 
   protected getExecutablePath(): string {

--- a/src/io.ts
+++ b/src/io.ts
@@ -18,6 +18,7 @@ export function parseInputs(): CommandOptions {
     action,
     install_dir,
     install_opt: {
+      butler_source: core.getInput('butler_source') || 'https://broth.itch.zone/butler',
       check_signature: stringToBool(core.getInput('check_signature'), true),
       update_path: stringToBool(core.getInput('update_path'), false),
       butler_version: core.getInput('butler_version') || 'latest'

--- a/src/io.ts
+++ b/src/io.ts
@@ -19,7 +19,7 @@ export function parseInputs(): CommandOptions {
     install_dir,
     install_opt: {
       butler_source: core.getInput('butler_source') || 'https://broth.itch.zone/butler',
-      check_signature: stringToBool(core.getInput('check_signature'), true),
+      check_signature: stringToBool(core.getInput('check_signature'), false),
       update_path: stringToBool(core.getInput('update_path'), false),
       butler_version: core.getInput('butler_version') || 'latest'
     },

--- a/src/models.ts
+++ b/src/models.ts
@@ -8,6 +8,7 @@ export type CommandOptions = {
 };
 
 export type CommandInstallOptions = {
+  butler_source: string;
   check_signature: boolean;
   update_path: boolean;
   butler_version: string;


### PR DESCRIPTION
* [Add butler_source configuration key](https://github.com/Ayowel/butler-to-itch/commit/f3da332de877aab5d6a41a5a30d1fe987d3e2a5d) Closes #6 : It is now possible to download Butler from a different source (e.g.: a private server in an isolated network). The source download URL for butler was also updated to broth.itch.zone (instead of broth.itch.ovh), as redirects broke the downloads from the documented source at the moment.
* [Limit cache reuse when downloading test files](https://github.com/Ayowel/butler-to-itch/commit/dc37d77f1811d3cdf0d46990e58026de7c959665): In tests, files were only downloaded based on their "final" name, not depending on the source URL, which could cause issues if two files with the same name but different paths were downloaded. This fix should limit the impact in such cases
* [Disable signature check as it is unsupported atm](https://github.com/Ayowel/butler-to-itch/commit/595f173cd7d2960ffd57af1f7964cc89760edbcf): The flag was enabled but the feature not supported, which resulted in a systematic error log in build outputs. This removes the need to explicitely disable signature checking until it is actually supported.
